### PR TITLE
Add CI with pre-commit configuration

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-builtin-literals
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: end-of-file-fixer
+      - id: name-tests-test
+      - id: pretty-format-json
+        args:
+          - "--autofix"
+          - "--no-ensure-ascii"
+          - "--no-sort-keys"
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        name: format code with black
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.5.2
+    hooks:
+      - id: isort

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,116 @@
+- id: check-added-large-files
+  name: check for added large files
+  description: prevents giant files from being committed.
+  entry: check-added-large-files
+  language: python
+- id: check-ast
+  name: check python ast
+  description: simply checks whether the files parse as valid python.
+  entry: check-ast
+  language: python
+  types: [python]
+- id: check-builtin-literals
+  name: check builtin type constructor use
+  description: requires literal syntax when initializing empty or zero python builtin types.
+  entry: check-builtin-literals
+  language: python
+  types: [python]
+- id: check-case-conflict
+  name: check for case conflicts
+  description: checks for files that would conflict in case-insensitive filesystems.
+  entry: check-case-conflict
+  language: python
+- id: check-docstring-first
+  name: check docstring is first
+  description: checks a common error of defining a docstring after code.
+  entry: check-docstring-first
+  language: python
+  types: [python]
+- id: check-executables-have-shebangs
+  name: check that executables have shebangs
+  description: ensures that (non-binary) executables have a shebang.
+  entry: check-executables-have-shebangs
+  language: python
+  types: [text, executable]
+  stages: [commit, push, manual]
+- id: check-json
+  name: check json
+  description: checks json files for parseable syntax.
+  entry: check-json
+  language: python
+  types: [json]
+- id: check-shebang-scripts-are-executable
+  name: check that scripts with shebangs are executable
+  description: ensures that (non-binary) files with a shebang are executable.
+  entry: check-shebang-scripts-are-executable
+  language: python
+  types: [text]
+  stages: [commit, push, manual]
+- id: pretty-format-json
+  name: pretty format json
+  description: sets a standard for formatting json files.
+  entry: pretty-format-json
+  language: python
+  types: [json]
+- id: check-merge-conflict
+  name: check for merge conflicts
+  description: checks for files that contain merge conflict strings.
+  entry: check-merge-conflict
+  language: python
+  types: [text]
+- id: check-symlinks
+  name: check for broken symlinks
+  description: checks for symlinks which do not point to anything.
+  entry: check-symlinks
+  language: python
+  types: [symlink]
+- id: check-toml
+  name: check toml
+  description: checks toml files for parseable syntax.
+  entry: check-toml
+  language: python
+  types: [toml]
+- id: check-yaml
+  name: check yaml
+  description: checks yaml files for parseable syntax.
+  entry: check-yaml
+  language: python
+  types: [yaml]
+- id: debug-statements
+  name: debug statements (python)
+  description: checks for debugger imports and py37+ `breakpoint()` calls in python source.
+  entry: debug-statement-hook
+  language: python
+  types: [python]
+- id: detect-private-key
+  name: detect private key
+  description: detects the presence of private keys.
+  entry: detect-private-key
+  language: python
+  types: [text]
+- id: end-of-file-fixer
+  name: fix end of files
+  description: ensures that a file is either empty, or ends with one newline.
+  entry: end-of-file-fixer
+  language: python
+  types: [text]
+  stages: [commit, push, manual]
+- id: name-tests-test
+  name: python tests naming
+  description: this verifies that test files are named correctly.
+  entry: name-tests-test
+  language: python
+  files: (^|/)tests/.+\.py$
+- id: requirements-txt-fixer
+  name: fix requirements.txt
+  description: sorts entries in requirements.txt.
+  entry: requirements-txt-fixer
+  language: python
+  files: requirements.*\.txt$
+- id: trailing-whitespace
+  name: trim trailing whitespace
+  description: trims trailing whitespace.
+  entry: trailing-whitespace-fixer
+  language: python
+  types: [text]
+  stages: [commit, push, manual]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Run the bot.
 bin/server
 ```
 
+Run the CI pipeline to ensure code quality and consistency across all repo.
+
+```
+bin/ci
+```
+
 Format the code accordingly to common guide lines.
 
 ```

--- a/bin/ci
+++ b/bin/ci
@@ -13,8 +13,5 @@ cd "${BASE_DIR}/.." || exit 127
 log_info "Loading virtual environment..."
 source .venv/bin/activate
 
-log_info "Sorting python imports..."
-python3 -m isort .
-
-log_info "Formatting python code..."
-python3 -m black .
+log_info "Running CI pipeline..."
+python3 -m pre_commit run --all-files

--- a/bin/format
+++ b/bin/format
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
 
-. scripts/helpers.sh
+set -Eeuo pipefail
 
+BASE_DIR=$(dirname "${BASH_SOURCE[0]:-$0}")
+cd "${BASE_DIR}/.." || exit 127
+
+# shellcheck source=../scripts/logging.sh
+. scripts/logging.sh
+# shellcheck source=../scripts/utils.sh
+. scripts/utils.sh
+
+log_info "Loading virtual environment..."
 source .venv/bin/activate
 
-yapf -vv -i -r bot/*.py
+log_info "Sorting python imports..."
+python3 -m isort .
+
+log_info "Formatting python code..."
+python3 -m black .
+

--- a/bin/lint
+++ b/bin/lint
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
 
-. scripts/helpers.sh
+set -Eeuo pipefail
 
+BASE_DIR=$(dirname "${BASH_SOURCE[0]:-$0}")
+cd "${BASE_DIR}/.." || exit 127
+
+# shellcheck source=../scripts/logging.sh
+. scripts/logging.sh
+# shellcheck source=../scripts/utils.sh
+. scripts/utils.sh
+
+log_info "Loading virtual environment..."
 source .venv/bin/activate
 
-pylint bot/*.py
-mypy --follow-imports=skip bot/*.py
+log_info "Running python linter..."
+python3 -m pylint bot/*.py
+
+log_info "Checking type system..."
+python3 -m mypy --follow-imports=skip bot/*.py

--- a/bin/server
+++ b/bin/server
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 
-. scripts/helpers.sh
+set -Eeuo pipefail
+
+BASE_DIR=$(dirname "${BASH_SOURCE[0]:-$0}")
+cd "${BASE_DIR}/.." || exit 127
+
+# shellcheck source=../scripts/logging.sh
+. scripts/logging.sh
+# shellcheck source=../scripts/utils.sh
+. scripts/utils.sh
 
 source .venv/bin/activate
 
-python -m bot
+python3 -m bot

--- a/bin/setup
+++ b/bin/setup
@@ -46,3 +46,6 @@ python3 -m pip install -r requirements.txt
 
 log_info "setup" "Installing dev dependencies..."
 python3 -m pip install -r requirements-dev.txt
+
+log_info "setup" "Register pre-commit as git hook..."
+python3 -m pre_commit install

--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-. scripts/helpers.sh
+set -Eeuo pipefail
+
+BASE_DIR=$(dirname "${BASH_SOURCE[0]:-$0}")
+cd "${BASE_DIR}/.." || exit 127
+
+# shellcheck source=../scripts/logging.sh
+. scripts/logging.sh
+# shellcheck source=../scripts/utils.sh
+. scripts/utils.sh
 
 if not_installed "asdf"; then
   echo_warning "
@@ -10,28 +18,31 @@ if not_installed "asdf"; then
     this script again, or proceed at your own peril.
   "
 else
+  set +e
   asdf plugin add python
+  set -e
+
   asdf install python $(read <.python-version)
 fi
 
-echo_info "setup" "Setting up the env file..."
+log_info "setup" "Setting up the env file..."
 if [ ! -f .env ]; then
   cp .env.sample .env
-  echo_done "env file created, you might want to open .env and set the correct values..."
+  log_done "env file created, you might want to open .env and set the correct values..."
   echo
 else
-  echo_warning ".env file already exists, skipping..."
+  log_warn ".env file already exists, skipping..."
   echo
 fi
 
-echo_info "setup" "Creating virtual environment..."
+log_info "setup" "Creating virtual environment..."
 python3 -m venv .venv
 
-echo_info "setup" "Activating virtual environment..."
+log_info "setup" "Activating virtual environment..."
 source .venv/bin/activate
 
-echo_info "setup" "Installing project dependencies..."
-python -m pip install -r requirements.txt
+log_info "setup" "Installing project dependencies..."
+python3 -m pip install -r requirements.txt
 
-echo_info "setup" "Installing dev dependencies..."
-python -m pip install -r requirements-dev.txt
+log_info "setup" "Installing dev dependencies..."
+python3 -m pip install -r requirements-dev.txt

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -2,4 +2,4 @@
 A bot for the CoderDojo Braga Discord server. Its goal is to help the Discord
 admins promote members in a more festive and easy way.
 """
-VERSION = '0.0.1'
+VERSION = "0.0.1"

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,5 +1,5 @@
 from bot.client import client
 from bot.settings import BOT_TOKEN
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     client.run(BOT_TOKEN)

--- a/bot/client.py
+++ b/bot/client.py
@@ -6,33 +6,32 @@ from discord.ext import commands
 from bot import VERSION
 
 client = commands.Bot(
-    command_prefix = commands.when_mentioned_or('$'),
-    help_command = None,
-    intents = discord.Intents.all(),
-    case_insensitive = True
+    command_prefix=commands.when_mentioned_or("$"),
+    help_command=None,
+    intents=discord.Intents.all(),
+    case_insensitive=True,
 )
+
 
 @client.event
 async def on_ready():
-    print(f'We have logged in as {client.user}')
+    print(f"We have logged in as {client.user}")
+
 
 @client.command()
 async def load(ctx, extension):
-    client.load_extension(f'bot.cogs.{extension}')
-    
-    await ctx.send(
-        f'O cog {extension} foi ativado.'
-    )
+    client.load_extension(f"bot.cogs.{extension}")
+
+    await ctx.send(f"O cog {extension} foi ativado.")
+
 
 @client.command()
 async def unload(ctx, extension):
-    client.unload_extension(f'bot.cogs.{extension}')
-    
-    await ctx.send(
-        f'O cog {extension} foi desativado.'
-    )
+    client.unload_extension(f"bot.cogs.{extension}")
 
-for filename in os.listdir('bot/cogs'):
-    if filename.endswith('.py'):
-        client.load_extension(f'bot.cogs.{filename[:-3]}')
+    await ctx.send(f"O cog {extension} foi desativado.")
 
+
+for filename in os.listdir("bot/cogs"):
+    if filename.endswith(".py"):
+        client.load_extension(f"bot.cogs.{filename[:-3]}")

--- a/bot/cogs/belts.json
+++ b/bot/cogs/belts.json
@@ -1,63 +1,70 @@
 {
-    "Branco": {
-        "objectives" : [
-            "- Finalizar um projeto sozinho",
-            "- Apresentar o teu projeto a outros ninjas",
-            "- Saber o nome de 5 ninjas e 2 mentores",
-            "- Completar o Lightbot"],
-        "color" : "FFFFFF"
-        },
-    "Amarelo" : {
-        "objectives" : [
-            "- Estar presente em 4 sessões", 
-            "- Fazer um projeto e apresentar à mesa"],
-        "color" : "F7E129"
-    },
-    "Azul" : {
-        "objectives" : [
-            "- Ajudar como mentor numa sessão",
-            "- Saber o nome de 7 ninjas e 4 mentores",
-            "- Conseguir completar o código que os mentores têm preparado para ti",
-            "- Fazer um site"],
-        "color" : "296DF7"
-        },
-    "Verde" : {
-        "objectives" : [
-            "- Apresentar um projeto para o Dojo inteiro",
-            "- Chegar a 5 Kyu em CodeWars",
-            "- Missão secreta n.º2",
-            "- Projeto em raspberry c/ apresentação"],
-        "color" : "0ACD1B"
-    },
-    "Laranja" : {
-        "objectives" : [
-            "- Projeto de Fuler",
-            "- Com a ajuda de um mentor, montar um computador",
-            "- Introduzir conceitos de bash",
-            "- Missão secreta n.º4 (difícil)"],
-        "color" : "F48005"
-    },
-    "Vermelho" : {
-        "objectives" : [
-            "- Ser mentor 1 sessão",
-            "- Demonstração de conhecimento do paradigma POO",
-            "- Ter um projeto que use API externa"],
-        "color" : "F60909"
-    },
-    "Roxo" : {
-        "objectives" : [
-            "- Conceitos básicos g7",
-            "- Criar uma missão secreta",
-            "- Ser mentor 2 sessões",
-            "- Ter conta e saber usar o Slack",
-            "- Criar um Bot com uma API externa",
-            "- Última missão secreta"],
-        "color" : "A709F6"
-    },
-    "Preto" : {
-        "objectives" : [
-            "Não tens, és um guru da programação!"
-        ],
-        "color" : "000000"
-    }
+  "Branco": {
+    "objectives": [
+      "- Finalizar um projeto sozinho",
+      "- Apresentar o teu projeto a outros ninjas",
+      "- Saber o nome de 5 ninjas e 2 mentores",
+      "- Completar o Lightbot"
+    ],
+    "color": "FFFFFF"
+  },
+  "Amarelo": {
+    "objectives": [
+      "- Estar presente em 4 sessões",
+      "- Fazer um projeto e apresentar à mesa"
+    ],
+    "color": "F7E129"
+  },
+  "Azul": {
+    "objectives": [
+      "- Ajudar como mentor numa sessão",
+      "- Saber o nome de 7 ninjas e 4 mentores",
+      "- Conseguir completar o código que os mentores têm preparado para ti",
+      "- Fazer um site"
+    ],
+    "color": "296DF7"
+  },
+  "Verde": {
+    "objectives": [
+      "- Apresentar um projeto para o Dojo inteiro",
+      "- Chegar a 5 Kyu em CodeWars",
+      "- Missão secreta n.º2",
+      "- Projeto em raspberry c/ apresentação"
+    ],
+    "color": "0ACD1B"
+  },
+  "Laranja": {
+    "objectives": [
+      "- Projeto de Fuler",
+      "- Com a ajuda de um mentor, montar um computador",
+      "- Introduzir conceitos de bash",
+      "- Missão secreta n.º4 (difícil)"
+    ],
+    "color": "F48005"
+  },
+  "Vermelho": {
+    "objectives": [
+      "- Ser mentor 1 sessão",
+      "- Demonstração de conhecimento do paradigma POO",
+      "- Ter um projeto que use API externa"
+    ],
+    "color": "F60909"
+  },
+  "Roxo": {
+    "objectives": [
+      "- Conceitos básicos g7",
+      "- Criar uma missão secreta",
+      "- Ser mentor 2 sessões",
+      "- Ter conta e saber usar o Slack",
+      "- Criar um Bot com uma API externa",
+      "- Última missão secreta"
+    ],
+    "color": "A709F6"
+  },
+  "Preto": {
+    "objectives": [
+      "Não tens, és um guru da programação!"
+    ],
+    "color": "000000"
+  }
 }

--- a/bot/cogs/belts.py
+++ b/bot/cogs/belts.py
@@ -1,39 +1,40 @@
-from enum import Enum, unique
-
 import json
+from enum import Enum, unique
 
 import discord
 from discord.ext import commands
 
-class FileHandler():
+
+class FileHandler:
     file = "bot/cogs/belts.json"
 
     def __init__(self, belt):
         self.belt = belt
         self.msg = self.get_info()[0]
         self.color = self.get_info()[1]
-    
+
     def get_info(self):
         with open(self.file) as json_file:
             data = json.load(json_file)
             msg = f"Subiste para {self.belt} :clap:\n\nPróximos objetivos:"
             color = int(data[self.belt]["color"], 16)
             for param in data[self.belt]["objectives"]:
-                msg += '\n' + param
+                msg += "\n" + param
 
-            return (
-                msg,
-                color
-            )
+            return (msg, color)
 
-translator_to_emoji = {"Branco" : ":white_circle:",
-                       "Amarelo" : ":yellow_circle:",
-                       "Azul" : ":blue_circle:",
-                       "Verde" : ":green_circle:",
-                       "Laranja" : ":orange_circle:",
-                       "Vermelho" : ":red_circle:",
-                       "Roxo" : ":purple_circle:",
-                       "Preto" : ":black_circle:"}
+
+translator_to_emoji = {
+    "Branco": ":white_circle:",
+    "Amarelo": ":yellow_circle:",
+    "Azul": ":blue_circle:",
+    "Verde": ":green_circle:",
+    "Laranja": ":orange_circle:",
+    "Vermelho": ":red_circle:",
+    "Roxo": ":purple_circle:",
+    "Preto": ":black_circle:",
+}
+
 
 @unique
 class Belts(Enum):
@@ -46,7 +47,8 @@ class Belts(Enum):
     Roxo = 7
     Preto = 8
 
-class Ninja():
+
+class Ninja:
     def __init__(self, guild, member):
         self.guild = guild
         self.member = member
@@ -58,26 +60,27 @@ class Ninja():
             for belt in Belts:
                 if belt.name == role.name:
                     highest_belt = belt
-        
+
         return highest_belt
 
     def next_belt(self):
-        # Check if the maximum range has been exceeded 
+        # Check if the maximum range has been exceeded
         value = self.current_belt().value + 1 if self.current_belt().value < 8 else 8
 
         return Belts(value)
-        
+
     @staticmethod
     def get_role_from_name(guild, belt):
         for role in guild.roles:
             if role.name == belt:
                 return role
 
+
 class BeltsAttributions(commands.Cog):
     def __init__(self, client):
         self.client = client
 
-    @commands.command(name = 'promove')
+    @commands.command(name="promove")
     @commands.has_any_role("🛡️ Admin", "🏆 Champion", "🧑‍🏫 Mentores")
     async def promove(self, ctx, user, belt):
 
@@ -88,64 +91,49 @@ class BeltsAttributions(commands.Cog):
 
         if belt == "Branco" and ninja.current_belt() == None:
             role = Ninja.get_role_from_name(guild, belt)
-            
-            await member.add_roles(
-                guild.get_role(role.id),
-                reason = None,
-                atomic = True
-            )
+
+            await member.add_roles(guild.get_role(role.id), reason=None, atomic=True)
 
             # Public message
-            await ctx.send(
-                f'{user} agora és cinturão {belt} :tada:'
-            )
-            
-            # Private message 
+            await ctx.send(f"{user} agora és cinturão {belt} :tada:")
+
+            # Private message
             file_handler = FileHandler(belt)
             emoji = translator_to_emoji[belt]
             user = member
             embed = discord.Embed(
-                title = f"{emoji} Parabéns, subiste de cinturão :tada:", 
-                description = file_handler.msg, 
-                color = file_handler.color
+                title=f"{emoji} Parabéns, subiste de cinturão :tada:",
+                description=file_handler.msg,
+                color=file_handler.color,
             )
-            
-            await user.send(embed = embed)
+
+            await user.send(embed=embed)
 
         elif belt == ninja.current_belt().name:
-            await ctx.reply(
-                f"Esse já é o cinturão do ninja {user}!"
-            )
-        
+            await ctx.reply(f"Esse já é o cinturão do ninja {user}!")
+
         elif belt == ninja.next_belt().name:
             role = Ninja.get_role_from_name(guild, belt)
-            await member.add_roles(
-                guild.get_role(role.id),
-                reason = None,
-                atomic = True
-            )
+            await member.add_roles(guild.get_role(role.id), reason=None, atomic=True)
 
             # Public message
-            await ctx.send(
-                f'{user} agora és cinturão {belt} :tada:'
-            )
-            
-            # Private message 
-            file_handler = FileHandler(belt)       
+            await ctx.send(f"{user} agora és cinturão {belt} :tada:")
+
+            # Private message
+            file_handler = FileHandler(belt)
             emoji = translator_to_emoji[belt]
             user = member
             embed = discord.Embed(
-                title = f"{emoji} Parabéns, subiste de cinturão :tada:", 
-                description = file_handler.msg, 
-                color = file_handler.color
+                title=f"{emoji} Parabéns, subiste de cinturão :tada:",
+                description=file_handler.msg,
+                color=file_handler.color,
             )
-            
-            await user.send(embed = embed)
+
+            await user.send(embed=embed)
 
         elif belt != ninja.next_belt().name:
-            await ctx.send(
-                f'{user} esse cinturão não é valido de se ser atribuido.'
-            )
+            await ctx.send(f"{user} esse cinturão não é valido de se ser atribuido.")
+
 
 def setup(client):
     client.add_cog(BeltsAttributions(client))

--- a/bot/settings.py
+++ b/bot/settings.py
@@ -1,6 +1,7 @@
 import os
+
 from dotenv import load_dotenv
 
 load_dotenv()
 
-BOT_TOKEN = os.environ['BOT_TOKEN']
+BOT_TOKEN = os.environ["BOT_TOKEN"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,6 @@ ipython==8.2.0
 isort==5.10.1
 mypy==0.942
 mypy-extensions==0.4.3
+pre-commit==2.19.0
 pylint==2.13.5
 python-dotenv==0.20.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
+black==22.3.0
+ipython==8.2.0
+isort==5.10.1
 mypy==0.942
 mypy-extensions==0.4.3
 pylint==2.13.5
 python-dotenv==0.20.0
-yapf==0.32.0
-ipython==8.2.0

--- a/scripts/LICENSE.txt
+++ b/scripts/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright © 2021 Nelson Estevão
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+RED=$(tput setaf 1)
+ORANGE=$(tput setaf 3)
+GREEN=$(tput setaf 2)
+PURPLE=$(tput setaf 5)
+CYAN=$(tput setaf 4)
+BLUE=$(tput setaf 6)
+WHITE=$(tput setaf 7)
+BOLD=$(tput bold)
+RESET=$(tput sgr0)

--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 RED=$(tput setaf 1)
 ORANGE=$(tput setaf 3)
 GREEN=$(tput setaf 2)

--- a/scripts/extras.sh
+++ b/scripts/extras.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+import() {
+  local -r SCRIPTS_DIR=$(dirname "${BASH_SOURCE[0]:-$0}")
+
+  # shellcheck source=/dev/null
+  . "${SCRIPTS_DIR}/${1}"
+}
+
+# shellcheck source=./helpers.sh
+import helpers.sh
+
+__set_trap() {
+  trap -p "$1" | grep "$2" &>/dev/null ||
+    trap '$2' "$1"
+}
+
+__kill_all_subprocesses() {
+  local i=""
+
+  for i in $(jobs -p); do
+    kill "$i"
+    wait "$i" &>/dev/null
+  done
+}
+
+__print_error_stream() {
+  while read -r line; do
+    echo -e "    ↳ ${RED}ERROR${RESET}: $line"
+  done
+}
+
+__print_result() {
+  if [ "$1" -eq 0 ]; then
+    echo -e " • $2 ${GREEN}✓${RESET}"
+  else
+    echo -e " • $2 ${RED}⨯${RESET}"
+  fi
+
+  return "$1"
+}
+
+# Ideas from https://github.com/alrra/dotfiles/blob/main/src/os/utils.sh
+__show_spinner() {
+  #local -r FRAMES='/-\|'
+  local -r FRAMES='⡿⣟⣯⣷⣾⣽⣻⢿'
+
+  # shellcheck disable=SC2034
+  local -r NUMBER_OR_FRAMES=${#FRAMES}
+
+  local -r CMDS="$2"
+  local -r MSG="$3"
+  local -r PID="$1"
+
+  local i=0
+  local frameText=""
+
+  # Note: In order for the Travis CI site to display
+  # things correctly, it needs special treatment, hence,
+  # the "is Travis CI?" checks.
+  if [ "${CI:-false}" != "true" ]; then
+    # Provide more space so that the text hopefully
+    # doesn't reach the bottom line of the terminal window.
+    #
+    # This is a workaround for escape sequences not tracking
+    # the buffer position (accounting for scrolling).
+    #
+    # See also: https://unix.stackexchange.com/a/278888
+    printf "\n\n\n"
+    tput cuu 3
+    tput sc
+  fi
+
+  # Display spinner while the commands are being executed.
+  while kill -0 "$PID" &>/dev/null; do
+    frameText=" • $MSG ${FRAMES:i++%NUMBER_OR_FRAMES:1}"
+
+    # Print frame text.
+    if [ "${CI:-false}" != "true" ]; then
+      printf "%s\n" "$frameText"
+    else
+      printf "%s" "$frameText"
+    fi
+
+    sleep 0.2
+
+    # Clear frame text.
+    if [ "${CI:-false}" != "true" ]; then
+      tput rc
+    else
+      printf "\r"
+    fi
+  done
+}
+
+function execute() {
+  local -r CMDS="$1"
+  local -r MSG="${2:-$1}"
+  local -r TMP_FILE="$(mktemp /tmp/XXXXX)"
+
+  local exitCode=0
+  local cmdsPID=""
+
+  # If the current process is ended, also end all its subprocesses.
+  __set_trap "EXIT" "__kill_all_subprocesses"
+
+  # Execute commands in background
+  eval "$CMDS" \
+    &>/dev/null \
+    2>"$TMP_FILE" &
+
+  cmdsPID=$!
+
+  # Show a spinner if the commands require more time to complete.
+  __show_spinner "$cmdsPID" "$CMDS" "$MSG"
+
+  # Wait for the commands to no longer be executing
+  # in the background, and then get their exit code.
+  wait "$cmdsPID" &>/dev/null
+  exitCode=$?
+
+  # Print output based on what happened.
+  __print_result $exitCode "$MSG"
+
+  if [ $exitCode -ne 0 ]; then
+    __print_error_stream <"$TMP_FILE"
+  fi
+
+  rm -rf "$TMP_FILE"
+
+  return $exitCode
+}
+
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.5 || true

--- a/scripts/extras.sh
+++ b/scripts/extras.sh
@@ -133,4 +133,4 @@ function execute() {
   return $exitCode
 }
 
-[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.5 || true
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.6 || true

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+import() {
+  local -r SCRIPTS_DIR=$(dirname "${BASH_SOURCE[0]:-$0}")
+
+  # shellcheck source=/dev/null
+  . "${SCRIPTS_DIR}/${1}"
+}
+
+# shellcheck source=./helpers.sh
+import helpers.sh
+
+__ansi() {
+  echo -e "\e[${1}m${*:2}\e[0m"
+}
+
+function bold() {
+  __ansi 1 "$@"
+}
+
+function italic() {
+  __ansi 3 "$@"
+}
+
+function underline() {
+  __ansi 4 "$@"
+}
+
+function strikethrough() {
+  __ansi 9 "$@"
+}
+
+function format() {
+  local COLOR=0 TYPE=0
+  local TEXT=()
+
+  while [[ $# -gt 0 ]]; do
+    key="$1"
+
+    case $key in
+      -c | --color)
+        case ${2:-reset} in
+          black)
+            COLOR=30
+            ;;
+          red)
+            COLOR=31
+            ;;
+          green)
+            COLOR=32
+            ;;
+          yellow)
+            COLOR=33
+            ;;
+          blue)
+            COLOR=34
+            ;;
+          magenta)
+            COLOR=35
+            ;;
+          cyan)
+            COLOR=36
+            ;;
+          white)
+            COLOR=37
+            ;;
+          reset)
+            COLOR=0
+            ;;
+        esac
+        shift 2
+        ;;
+      -t | --type)
+        case ${2:-reset} in
+          bold | bright)
+            TYPE=1
+            ;;
+          fade)
+            TYPE=2
+            ;;
+          italic)
+            TYPE=3
+            ;;
+          underline)
+            TYPE=4
+            ;;
+          blink)
+            TYPE=5
+            ;;
+          inverse)
+            TYPE=7
+            ;;
+          strikethrough)
+            TYPE=9
+            ;;
+          reset)
+            TYPE=0
+            ;;
+        esac
+        shift 2
+        ;;
+      *)
+        TEXT+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  if ((COLOR > 0)); then
+    echo -en "\\033[${TYPE:-0};${COLOR:-0}m"
+  else
+    echo -en "\\033[0;${TYPE:-0}m"
+  fi
+
+  if [[ ${#TEXT[@]} -gt 1 ]]; then
+    for text in "${TEXT[@]}"; do
+      echo "$text"
+    done
+
+    echo -en '\033[0;0m'
+  elif [[ ${#TEXT[@]} -eq 1 ]]; then
+    for text in "${TEXT[@]}"; do
+      echo -n "$text"
+    done
+
+    echo -en '\033[0;0m'
+  fi
+}
+
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.5 || true

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -129,4 +129,4 @@ function format() {
   fi
 }
 
-[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.5 || true
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.6 || true

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -31,4 +31,4 @@ function help_title_section() {
   echo -e "${BOLD}${TITLE}${RESET}"
 }
 
-[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.5 || true
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.6 || true

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,80 +1,34 @@
 #!/usr/bin/env bash
 
-function colorize() {
-  local color type=0
+set -Eeuo pipefail
 
-  case $1 in
-    black)
-      color=30
-      ;;
-    red)
-      color=31
-      ;;
-    green)
-      color=32
-      ;;
-    yellow)
-      color=33
-      ;;
-    blue)
-      color=34
-      ;;
-    magenta)
-      color=35
-      ;;
-    cyan)
-      color=36
-      ;;
-    white)
-      color=37
-      ;;
-    reset | *)
-      color=0
-      ;;
-  esac
+import() {
+  local -r SCRIPTS_DIR=$(dirname "${BASH_SOURCE[0]:-$0}")
 
-  case $2 in
-    bold | bright)
-      type=1
-      ;;
-    underline)
-      type=4
-      ;;
-    inverse)
-      type=7
-      ;;
-  esac
-
-  echo -en "\\033[${type};${color}m"
+  # shellcheck source=/dev/null
+  . "${SCRIPTS_DIR}/${1}"
 }
 
-function echo_error() {
-  colorize red bold
-  echo "ERROR:$(colorize reset)" "$@"
-}
+# shellcheck source=./colors.sh
+import colors.sh
 
-function echo_warning() {
-  colorize yellow bold
-  echo "WARNING:$(colorize reset)" "$@"
-}
+function display_version() {
+  local program="${2:-$(basename "$0")}"
+  local version=${1:?"You need to give a version number"}
 
-function echo_done() {
-  colorize green bold
-  echo "DONE:$(colorize reset)" "$@"
-}
-
-function echo_info() {
-  colorize cyan bold
-  if (( $# < 2 )); then
-    echo "INFO:$(colorize reset)" "$@"
+  if [ -x "$(command -v figlet)" ]; then
+    echo -n "${BLUE}${BOLD}"
+    figlet "${program} script"
+    echo -n "${RESET}"
+    echo "version ${version}"
   else
-    printf "[%s] $(colorize reset)" "$1"
-    shift 1
-    echo "$@"
+    echo "${program} script version ${version}"
   fi
 }
 
-function not_installed() {
-  [ ! -x "$(command -v "$@")" ]
+function help_title_section() {
+  local -r TITLE=$(echo "$@" | tr '[:lower:]' '[:upper:]')
+  echo -e "${BOLD}${TITLE}${RESET}"
 }
 
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.5 || true

--- a/scripts/logging.sh
+++ b/scripts/logging.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+import() {
+  local -r SCRIPTS_DIR=$(dirname "${BASH_SOURCE[0]:-$0}")
+
+  # shellcheck source=/dev/null
+  . "${SCRIPTS_DIR}/${1}"
+}
+
+# shellcheck source=./helpers.sh
+import helpers.sh
+
+function __log() {
+  local LABEL="$1"
+  local COLOR="$2"
+  shift 2
+  local MSG=("$@")
+
+  local SIZE
+  [[ $(tput cols) -ge 80 ]] && SIZE=80 || SIZE=$(tput cols)
+
+  # Get symbols from https://coolsymbol.com/
+  printf "_${COLOR}${BOLD}${LABEL}${RESET}_╞%*s\n" $((SIZE - ${#LABEL} - 3)) " " | sed -e 's/ /═/g' | sed -e 's/_/ /g'
+  for M in "${MSG[@]}"; do
+    echo "• $M"
+  done
+  printf "%*s\n" "$SIZE" " " | sed -e 's/ /═/g'
+}
+
+function log_error() {
+  __log "FAIL" "$RED" "$@"
+}
+
+function log_warn() {
+  __log "WARN" "$ORANGE" "$@"
+}
+
+function log_success() {
+  __log "OK" "$GREEN" "$@"
+}
+
+function log_info() {
+  local LABEL="INFO"
+
+  if ! [ "$#" -eq 1 ]; then
+    LABEL=$(echo "$1" | tr '[:lower:]' '[:upper:]')
+    shift 1
+  fi
+
+  __log "${LABEL}" "$CYAN" "$@"
+}
+
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.5 || true

--- a/scripts/logging.sh
+++ b/scripts/logging.sh
@@ -52,4 +52,4 @@ function log_info() {
   __log "${LABEL}" "$CYAN" "$@"
 }
 
-[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.5 || true
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.6 || true

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+import() {
+  local -r SCRIPTS_DIR=$(dirname "${BASH_SOURCE[0]:-$0}")
+
+  # shellcheck source=/dev/null
+  . "${SCRIPTS_DIR}/${1}"
+}
+
+# shellcheck source=./helpers.sh
+import helpers.sh
+
+function not_installed() {
+  [ ! -x "$(command -v "$@")" ]
+}
+
+function load_env_file() {
+  local file="${1:-.env}"
+  if [ -f "$file" ]; then
+    log_info "Environment" "Loading ${BLUE}${file}${RESET}..." $(cat "${file}")
+    set -o allexport
+    source "$file"
+    set +o allexport
+  else
+    log_warn "${file} file not found, skipping..."
+  fi
+}
+
+function ask_for_sudo() {
+  # Ask for the administrator password upfront.
+  sudo -v &>/dev/null
+
+  # Update existing `sudo` time stamp
+  # until this script has finished.
+  #
+  # https://gist.github.com/cowboy/3118588
+  while true; do
+    sudo -n true
+    sleep 60
+    kill -0 "$$" || exit
+  done &>/dev/null &
+}
+
+function ensure_confirmation() {
+  read -r "confirmation?please confirm you want to continue [y/n] (default: y) "
+  confirmation=${confirmation:-"y"}
+
+  if [ "$confirmation" != "y" ]; then
+    exit 1
+  fi
+}
+
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.5 || true

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -52,4 +52,4 @@ function ensure_confirmation() {
   fi
 }
 
-[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.5 || true
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.6 || true


### PR DESCRIPTION
For keeping consistency, we follow a set of rules that tools like code formatters and linters help maintain those previously agreed rules. Recently, we decided upon black instead of yapf and this PR is changing that. I used [pre-commit](https://pre-commit.com/) to help automated that process into an [GitHub Action](https://github.com/features/actions).

### Achievements 

- [x] Replaced yapf by black as our code formatter
- [x] Added isort to keep the import order consistent
- [x] Created a `bin/ci` script to easily run all the rules (json format, requirements order, etc - see the `.pre-commit-config.yaml` for more)
- [x] Updated utility scripts to latest version available
- [x] Added pre-commit as a git hook in the `bin/setup` step  