### PR TITLE
Fix lint file

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -17,4 +17,4 @@ log_info "Running python linter..."
 python3 -m pylint bot/*.py
 
 log_info "Checking type system..."
-python3 -m mypy --follow-imports=skip bot/*.py
+python3 -m mypy --follow-imports=skip bot/**/*.py


### PR DESCRIPTION
Right now, the linter was not checking for files inside the `cogs` folder, so that, we need to use a double asterisk as a wildcard.