### PR TITLE
Refactor Enum Classes

### DIFF
--- a/bot/cogs/belts.py
+++ b/bot/cogs/belts.py
@@ -66,25 +66,28 @@ class Ninja:
     def __init__(self, guild: discord.Guild, member: discord.Member):
         self.guild = guild
         self.member = member
-        self.roles = [role for role in member.roles]
+        self.roles = list(member.roles)
 
-    def current_belt(self) -> Belts:
+    def current_belt(self):
         """This function returns the current belt of the ninja."""
 
         highest_belt = None
         for role in self.roles:
-            for belt in Belts:
-                if belt.name == role.name:
+            for index in range(0, 7):
+                belt = list_roles[index]
+                if belt["name"] == role.name:
                     highest_belt = belt
 
         return highest_belt
 
-    def next_belt(self) -> Belts:
+    def next_belt(self):
         """This function returns the next belt of the ninja."""
 
-        value = self.current_belt().value + 1 if self.current_belt().value < 8 else 8
+        value = (
+            self.current_belt()["value"] + 1 if self.current_belt()["value"] < 8 else 8
+        )
 
-        return Belts(value)
+        return list_roles[value - 1]
 
 
 class BeltsAttributions(commands.Cog):
@@ -94,7 +97,7 @@ class BeltsAttributions(commands.Cog):
         self.client = client
 
     @commands.command(name="promove")
-    @commands.has_any_role("🛡️ Admin", "🏆 Champion", "🧑‍🏫 Mentores")
+    @commands.has_any_role(ADMIN["name"], CHAMPION["name"], MENTOR["name"])
     async def promove(
         self, ctx: discord.ext.commands.Context, user: str, belt: str
     ) -> None:
@@ -136,10 +139,10 @@ class BeltsAttributions(commands.Cog):
             session.add(new_log)
             session.commit()
 
-        elif belt == ninja.current_belt().name:
+        elif belt == ninja.current_belt()["name"]:
             await ctx.reply(f"Esse já é o cinturão do ninja {user}!")
 
-        elif belt == ninja.next_belt().name:
+        elif belt == ninja.next_belt()["name"]:
             role = get_role_from_name(guild, belt)
             await member.add_roles(guild.get_role(role.id), reason=None, atomic=True)
 
@@ -169,7 +172,7 @@ class BeltsAttributions(commands.Cog):
             session.add(new_log)
             session.commit()
 
-        elif belt != ninja.next_belt().name:
+        elif belt != ninja.next_belt()["name"]:
             await ctx.send(f"{user} esse cinturão não é valido de se ser atribuido.")
 
 

--- a/bot/cogs/belts.py
+++ b/bot/cogs/belts.py
@@ -73,21 +73,20 @@ class Ninja:
 
         highest_belt = None
         for role in self.roles:
-            for index in range(0, 7):
-                belt = list_roles[index]
-                if belt["name"] == role.name:
+            for belt in Belts:
+                if belt.name == role.name:
                     highest_belt = belt
 
         return highest_belt
 
-    def next_belt(self):
+        return highest_belt
+
+    def next_belt(self) -> Belts:
         """This function returns the next belt of the ninja."""
 
-        value = (
-            self.current_belt()["value"] + 1 if self.current_belt()["value"] < 8 else 8
-        )
+        value = self.current_belt().value + 1 if self.current_belt().value < 8 else 8
 
-        return list_roles[value - 1]
+        return Belts(value)
 
 
 class BeltsAttributions(commands.Cog):
@@ -97,7 +96,9 @@ class BeltsAttributions(commands.Cog):
         self.client = client
 
     @commands.command(name="promove")
-    @commands.has_any_role(ADMIN["name"], CHAMPION["name"], MENTOR["name"])
+    @commands.has_any_role(
+        Roles["ADMIN"].name, Roles["CHAMPION"].name, Roles["MENTOR"].name
+    )
     async def promove(
         self, ctx: discord.ext.commands.Context, user: str, belt: str
     ) -> None:
@@ -139,10 +140,10 @@ class BeltsAttributions(commands.Cog):
             session.add(new_log)
             session.commit()
 
-        elif belt == ninja.current_belt()["name"]:
+        elif belt == ninja.current_belt().name:
             await ctx.reply(f"Esse já é o cinturão do ninja {user}!")
 
-        elif belt == ninja.next_belt()["name"]:
+        elif belt == ninja.next_belt().name:
             role = get_role_from_name(guild, belt)
             await member.add_roles(guild.get_role(role.id), reason=None, atomic=True)
 
@@ -172,7 +173,7 @@ class BeltsAttributions(commands.Cog):
             session.add(new_log)
             session.commit()
 
-        elif belt != ninja.next_belt()["name"]:
+        elif belt != ninja.next_belt().name:
             await ctx.send(f"{user} esse cinturão não é valido de se ser atribuido.")
 
 

--- a/bot/cogs/utils/constants.py
+++ b/bot/cogs/utils/constants.py
@@ -2,6 +2,7 @@ from enum import Enum, unique
 
 import discord
 from discord.ext import commands
+from emoji import emojize
 
 translator_to_emoji = {
     "Branco": ":white_circle:",
@@ -14,25 +15,37 @@ translator_to_emoji = {
     "Preto": ":black_circle:",
 }
 
-list_roles = [
-    {"value": 1, "name": "Branco"},
-    {"value": 2, "name": "Amarelo"},
-    {"value": 3, "name": "Azul"},
-    {"value": 4, "name": "Verde"},
-    {"value": 5, "name": "Laranja"},
-    {"value": 6, "name": "Vermelho"},
-    {"value": 7, "name": "Roxo"},
-    {"value": 8, "name": "Preto"},
-    {"value": 9, "name": ":🙋 Voluntários"},
-    {"value": 10, "name": "🧑‍🏫 Mentores"},
-    {"value": 11, "name": "🛡️ Admin"},
-    {"value": 12, "name": "🏆 Champion"},
-]
+Roles = Enum(
+    value="Roles",
+    names=[
+        (emojize(":older_man: Guardiões"), 1),
+        ("GUARDIOES", 1),
+        (emojize(":ninja: Ninja"), 2),
+        ("NINJAS", 2),
+        (emojize(":person_raising_hand: Voluntários"), 3),
+        ("VOLUNTARIOS", 3),
+        (emojize(":teacher: Mentores"), 4),
+        ("MENTOR", 4),
+        (emojize(":shield: Admin"), 5),
+        ("ADMIN", 5),
+        (emojize(":trophy: Champion"), 6),
+        ("CHAMPION", 6),
+    ],
+)
 
-VOLUNTARIO = list_roles[8]
-MENTOR = list_roles[9]
-ADMIN = list_roles[10]
-CHAMPION = list_roles[11]
+Belts = Enum(
+    value="Belts",
+    names=[
+        ("Branco", 1),
+        ("Amarelo", 2),
+        ("Azul", 3),
+        ("Verde", 4),
+        ("Laranja", 5),
+        ("Vermelho", 6),
+        ("Roxo", 7),
+        ("Preto", 8),
+    ],
+)
 
 
 def get_role_from_name(guild: discord.Guild, belt: str) -> discord.Role:

--- a/bot/cogs/utils/constants.py
+++ b/bot/cogs/utils/constants.py
@@ -14,17 +14,25 @@ translator_to_emoji = {
     "Preto": ":black_circle:",
 }
 
+list_roles = [
+    {"value": 1, "name": "Branco"},
+    {"value": 2, "name": "Amarelo"},
+    {"value": 3, "name": "Azul"},
+    {"value": 4, "name": "Verde"},
+    {"value": 5, "name": "Laranja"},
+    {"value": 6, "name": "Vermelho"},
+    {"value": 7, "name": "Roxo"},
+    {"value": 8, "name": "Preto"},
+    {"value": 9, "name": ":🙋 Voluntários"},
+    {"value": 10, "name": "🧑‍🏫 Mentores"},
+    {"value": 11, "name": "🛡️ Admin"},
+    {"value": 12, "name": "🏆 Champion"},
+]
 
-@unique
-class Belts(Enum):
-    Branco = 1
-    Amarelo = 2
-    Azul = 3
-    Verde = 4
-    Laranja = 5
-    Vermelho = 6
-    Roxo = 7
-    Preto = 8
+VOLUNTARIO = list_roles[8]
+MENTOR = list_roles[9]
+ADMIN = list_roles[10]
+CHAMPION = list_roles[11]
 
 
 def get_role_from_name(guild: discord.Guild, belt: str) -> discord.Role:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 discord==1.0.1
 discord.py==1.7.3
+emoji==1.7.0
 python-dotenv==0.20.0
 SQLAlchemy==1.4.37


### PR DESCRIPTION
Due to a previous request of not using the role names hard coded and also after me noticing that the role names in my testing discord server and the actual coder dojo discord server didn't coincide a refactor was necessary. 
In this PR I decided to drop Enum classes for the simple fact that I couldn't associate more information to the Enum class objects, and substitute it for a list of dictionaries where we can add more data about a specific Belt/Role and quickly change the role names.

### Achievements 
- [x] Refactor the Enum class to a dictionary list
- [x] Replace all the Roles directly coded, for variables 