### PR TITLE
Create help command

### DIFF
--- a/bot/client.py
+++ b/bot/client.py
@@ -52,5 +52,7 @@ async def unload(ctx: discord.ext.commands.Context, extension: str):
     await ctx.send(f"O cog {extension} foi desativado.")
 
 
+# Load extensions
 client.load_extension("bot.cogs.belts")
 client.load_extension("bot.cogs.daily_report")
+client.load_extension("bot.cogs.help")

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -1,0 +1,29 @@
+import discord
+from discord.ext import commands
+
+
+class Help(commands.Cog):
+    def __init__(self, client: commands.Bot):
+        self.client = client
+
+    @commands.command(name="help")
+    async def help(self, ctx: discord.ext.commands.Context) -> None:
+
+        # Embed sent by the bot
+        embed = discord.Embed(
+            title="Comandos: [Obrigatório] <Opcional> (alias)", color=0x3489EB
+        )
+
+        fields = [
+            ("$help", "É preciso apresentações?"),
+            ("$promove [ninja] [cinturão]", "Promove um ninja para o cinturão dado."),
+        ]
+
+        for name, value in fields:
+            embed.add_field(name=name, value=value, inline=False)
+
+        await ctx.reply(embed=embed)
+
+
+def setup(client):
+    client.add_cog(Help(client))


### PR DESCRIPTION
Creating an help command (`$help`) is an added value to the bot. The bot is expanding and there will be new commands in the near future.

The command is sending an embed that looks like this, right now:
![image](https://user-images.githubusercontent.com/76881129/180667638-26206334-0483-44cb-ad0a-ea4db4113f96.png)
